### PR TITLE
Fix failing fills_and_removes_from_window test

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -191,7 +191,8 @@ mod tests {
     fn initialize(file_name: &str) -> File {
         let file_name = DIR_NAME.to_string() + "/" + file_name;
         if !Path::new(DIR_NAME).is_dir() {
-            fs::create_dir(DIR_NAME).unwrap();
+            if fs::create_dir(DIR_NAME).is_err() {
+            }
         }
 
         if File::open(&file_name).is_ok() {


### PR DESCRIPTION
As the tests are run concurrently, the directory might already exist, so just ignore the failure.

Fixes the following error when running the tests:

---- window::tests::fills_and_removes_from_window stdout ---- thread 'window::tests::fills_and_removes_from_window' panicked at 'called `Result::unwrap()` on an `Err` value: Os { code: 17, kind: AlreadyExists, message: "File exists" }', src/window.rs:194:38

Fixes #3 