### PR TITLE
Wait 1 millisecond between duplicate packets

### DIFF
--- a/src/worker.rs
+++ b/src/worker.rs
@@ -9,6 +9,7 @@ use std::{
 
 const MAX_RETRIES: u32 = 6;
 const TIMEOUT_BUFFER: Duration = Duration::from_secs(1);
+const DEFAULT_DUPLICATE_DELAY: Duration = Duration::from_millis(1);
 
 /// Worker `struct` is used for multithreaded file sending and receiving.
 /// It creates a new socket using the Server's IP and a random port
@@ -241,7 +242,10 @@ impl<T: Socket + ?Sized> Worker<T> {
     }
 
     fn send_packet(&self, packet: &Packet) -> Result<(), Box<dyn Error>> {
-        for _ in 0..self.repeat_amount {
+        for i in 0..self.repeat_amount {
+            if i > 0 {
+                std::thread::sleep(DEFAULT_DUPLICATE_DELAY);
+            }
             self.socket.send(packet)?;
         }
 

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -9,6 +9,7 @@ use std::{
 
 const MAX_RETRIES: u32 = 6;
 const TIMEOUT_BUFFER: Duration = Duration::from_secs(1);
+const DEFAULT_DUPLICATE_DELAY: Duration = Duration::from_millis(1);
 
 /// Worker `struct` is used for multithreaded file sending and receiving.
 /// It creates a new socket using the Server's IP and a random port
@@ -241,7 +242,10 @@ impl<T: Socket + ?Sized> Worker<T> {
     }
 
     fn send_packet(&self, packet: &Packet) -> Result<(), Box<dyn Error>> {
-        for _ in 0..self.duplicate_packets {
+        for i in 0..self.duplicate_packets {
+            if i > 0 {
+                std::thread::sleep(DEFAULT_DUPLICATE_DELAY);
+            }
             self.socket.send(packet)?;
         }
 


### PR DESCRIPTION
Hi: Thanks for adding the option for Duplicate Packets. Based on my testing, we need to insert 1 millisecond delay between the Duplicate Packets. (Should this be another option?)

__Without Delay:__ U-Boot JH7110 boots slower (5.7 Mbps), with 2 TFTP Timeouts

```text
Filename 'initrd'.
Loading: 711.9 KiB/s
Bytes transferred = 8100864 (7b9c00 hex)
```

__With Delay (1 millisecond):__ U-Boot JH7110 boots faster (8.8 Mbps), with No TFTP Timeouts

```text
Filename 'initrd'.
Loading: 1.1 MiB/s
Bytes transferred = 8100864 (7b9c00 hex)
```

This was tested on macOS over Wired Ethernet. Thanks :-)

```bash
cd ~/rs-tftpd
sudo cargo run -- \
  --duplicate-packets 2 \
  -i 0.0.0.0 \
  -p 69 \
  -d "$HOME/tftproot"
```
