### PR TITLE
Fix duplicate packets when set to 0

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -45,7 +45,7 @@ impl Config {
             directory: env::current_dir().unwrap_or_else(|_| env::temp_dir()),
             single_port: false,
             read_only: false,
-            duplicate_packets: 1,
+            duplicate_packets: 0,
             overwrite: false,
         };
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -221,7 +221,7 @@ impl Server {
                 worker_options.block_size,
                 worker_options.timeout,
                 worker_options.window_size,
-                self.duplicate_packets,
+                self.duplicate_packets + 1,
             );
             worker.receive()
         };


### PR DESCRIPTION
This should fix issue #9 and #10 by making the duplicate packets == 0 as the default config and also fix the receiving of files in case duplicate packets == 0.