### PR TITLE
doc(config): Update default to reflect value in new

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,7 +33,7 @@ pub struct Config {
     pub single_port: bool,
     /// Refuse all write requests, making the server read-only. (default: false)
     pub read_only: bool,
-    /// Duplicate all packets sent from the server. (default: 1)
+    /// Duplicate all packets sent from the server. (default: 0)
     pub duplicate_packets: u8,
     /// Overwrite existing files. (default: false)
     pub overwrite: bool,


### PR DESCRIPTION
I noticed that the default value in the comment didn't reflect the value actually used in the new method. Looking back through history, it looks like we forgot to update this comment as a part of https://github.com/altugbakan/rs-tftpd/pull/11

Let's update the comment.