### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+The TFTP Server Daemon project team and community take security bugs in this repository seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+## Reporting a Vulnerability
+To report a security issue, please use one of the following methods:
+- **GitHub Security Advisory:** Use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/altugbakan/rs-tftpd/security/advisories/new) tab on our GitHub repository.
+- **Send an Email:** Send your report to mail@alt.ug. We recommend encrypting the email if possible.
+
+Please **DO NOT** use public channels (e.g., GitHub issues) for initial reporting of bona fide security vulnerabilities.
+Once you report a security issue, our team will respond with the next steps. After our initial reply, we will keep you informed of the progress towards a fix and full announcement. We may ask for additional information or guidance during this process. If we disagree that your report constitutes a genuine security vulnerability, we will inform you and close the report. Your report may be turned into an issue for further tracking.
+
+## Security Issues in Third-Party Dependencies
+If you discover vulnerabilities in third-party modules used by this project, please report them to the maintainers of the respective modules. If the vulnerability impacts TFTP Server Daemon project directly, we encourage you to notify us using the above methods. We will validate if the vulnerability is exploitable from repository code; please note that not all vulnerabilities are actually exploitable and do not constitute an immediate concern for the project.
+
+## Security Recommendations
+Since TFTP lacks login or access control mechanisms, the server limits file transfers to a designated folder. It is highly recommended to run the server in a secure and isolated environment to prevent unauthorized file access and to only enable read-only mode if file uploads are not required.
+
+Thank you for helping us keep the TFTP Server Daemon project secure!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,9 +2,7 @@
 The TFTP Server Daemon project takes security bugs in this repository seriously. Your efforts to responsibly disclose your findings is appreciated, and we will make every effort to acknowledge your contributions.
 
 ## Reporting a Vulnerability
-To report a security issue, please use one of the following methods:
-- **GitHub Security Advisory:** Use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/altugbakan/rs-tftpd/security/advisories/new) tab on our GitHub repository.
-- **Send an Email:** Send your report to mail@alt.ug. Encrypting the email is recommended, if possible.
+To report a security issue, please use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/altugbakan/rs-tftpd/security/advisories/new) tab on our GitHub repository.
 
 Please **DO NOT** use public channels (e.g., GitHub issues) for initial reporting of bona fide security vulnerabilities.
 Once you report a security issue, a reviewer will respond with the next steps. After the initial reply, you will be kept informed of the progress towards a fix and any forthcoming announcements. The reviewer may ask for additional information or guidance during this process. If we determine that your report does not constitute a genuine security vulnerability, you will be informed and the report will be closed. Your report may be turned into an issue for further tracking.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,16 +1,13 @@
 # Security Policy
-The TFTP Server Daemon project team and community take security bugs in this repository seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+The TFTP Server Daemon project takes security bugs in this repository seriously. Your efforts to responsibly disclose your findings is appreciated, and we will make every effort to acknowledge your contributions.
 
 ## Reporting a Vulnerability
 To report a security issue, please use one of the following methods:
 - **GitHub Security Advisory:** Use the GitHub Security Advisory ["Report a Vulnerability"](https://github.com/altugbakan/rs-tftpd/security/advisories/new) tab on our GitHub repository.
-- **Send an Email:** Send your report to mail@alt.ug. We recommend encrypting the email if possible.
+- **Send an Email:** Send your report to mail@alt.ug. Encrypting the email is recommended, if possible.
 
 Please **DO NOT** use public channels (e.g., GitHub issues) for initial reporting of bona fide security vulnerabilities.
-Once you report a security issue, our team will respond with the next steps. After our initial reply, we will keep you informed of the progress towards a fix and full announcement. We may ask for additional information or guidance during this process. If we disagree that your report constitutes a genuine security vulnerability, we will inform you and close the report. Your report may be turned into an issue for further tracking.
-
-## Security Issues in Third-Party Dependencies
-If you discover vulnerabilities in third-party modules used by this project, please report them to the maintainers of the respective modules. If the vulnerability impacts TFTP Server Daemon project directly, we encourage you to notify us using the above methods. We will validate if the vulnerability is exploitable from repository code; please note that not all vulnerabilities are actually exploitable and do not constitute an immediate concern for the project.
+Once you report a security issue, a reviewer will respond with the next steps. After the initial reply, you will be kept informed of the progress towards a fix and any forthcoming announcements. The reviewer may ask for additional information or guidance during this process. If we determine that your report does not constitute a genuine security vulnerability, you will be informed and the report will be closed. Your report may be turned into an issue for further tracking.
 
 ## Security Recommendations
 Since TFTP lacks login or access control mechanisms, the server limits file transfers to a designated folder. It is highly recommended to run the server in a secure and isolated environment to prevent unauthorized file access and to only enable read-only mode if file uploads are not required.


### PR DESCRIPTION
Hi, opening this PR to share a draft for the rs-tftpd repository. Please feel free to propose any changes/feedback :)

I also noticed that the URL for submitting a security advisory ([this link](https://github.com/altugbakan/rs-tftpd/security/advisories/new)) currently results in a 404 error, likely because security advisories are not enabled for the repository.
Kindly enable the feature as it will be part of the documentation (the _Reporting a Vulnerability_ section).

Thank you for your time, and I look forward to your thoughts on the draft!