### PR TITLE
Add graceful error handling for less than 2 bytes packet

### DIFF
--- a/src/packet.rs
+++ b/src/packet.rs
@@ -58,6 +58,9 @@ pub enum Packet {
 impl Packet {
     /// Deserializes a [`u8`] slice into a [`Packet`].
     pub fn deserialize(buf: &[u8]) -> Result<Packet, Box<dyn Error>> {
+        if buff.len < 2 {
+            return Err("Buffer too short to serialize".into());
+        }
         let opcode = Opcode::from_u16(Convert::to_u16(&buf[0..=1])?)?;
 
         match opcode {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -58,7 +58,7 @@ pub enum Packet {
 impl Packet {
     /// Deserializes a [`u8`] slice into a [`Packet`].
     pub fn deserialize(buf: &[u8]) -> Result<Packet, Box<dyn Error>> {
-        if buff.len < 2 {
+        if buf.len < 2 {
             return Err("Buffer too short to serialize".into());
         }
         let opcode = Opcode::from_u16(Convert::to_u16(&buf[0..=1])?)?;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -58,7 +58,7 @@ pub enum Packet {
 impl Packet {
     /// Deserializes a [`u8`] slice into a [`Packet`].
     pub fn deserialize(buf: &[u8]) -> Result<Packet, Box<dyn Error>> {
-        if buf.len < 2 {
+        if buf.len() < 2 {
             return Err("Buffer too short to serialize".into());
         }
         let opcode = Opcode::from_u16(Convert::to_u16(&buf[0..=1])?)?;


### PR DESCRIPTION
When request for a single byte is made it panics (see below). Adding code to gracefully error out when a single byte is sent, as it doesn’t align with standard tftp protocol.


```
thread 'main' panicked at src/packet.rs:61:59:
range end index 2 out of range for slice of length 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```