### PR TITLE
Pull req 1: retries / tsize / timeout

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -30,6 +30,7 @@ pub struct Client {
     blocksize: usize,
     windowsize: u16,
     timeout: Duration,
+    timeout_req: Duration,
     max_retries: usize,
     mode: Mode,
     file_path: PathBuf,
@@ -55,6 +56,7 @@ impl Client {
             blocksize: config.blocksize,
             windowsize: config.windowsize,
             timeout: config.timeout,
+            timeout_req: config.timeout_req,
             max_retries: config.max_retries,
             mode: config.mode,
             file_path: config.file_path.clone(),
@@ -72,6 +74,8 @@ impl Client {
         } else {
             UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0))?
         };
+
+        socket.set_read_timeout(Some(self.timeout_req))?;
 
         match self.mode {
             Mode::Upload => self.upload(socket),

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -102,7 +102,14 @@ impl ClientConfig {
                 }
                 "-t" | "--timeout" => {
                     if let Some(timeout_str) = args.next() {
-                        config.timeout = Duration::from_secs(timeout_str.parse::<u64>()?);
+                        if timeout_str.contains('.') {
+                            config.timeout = Duration::from_secs_f32(timeout_str.parse::<f32>()?);
+                            if config.timeout < Duration::from_secs_f32(0.001) {
+                                return Err("timeout cannot be shorter than 1 ms".into());
+                            }                           
+                        } else {
+                            config.timeout = Duration::from_secs(timeout_str.parse::<u64>()?);
+                        }
                     } else {
                         return Err("Missing timeout after flag".into());
                     }
@@ -134,13 +141,11 @@ impl ClientConfig {
                     println!("  -p, --port <PORT>\t\t\tPort of the server (default: 69)");
                     println!("  -b, --blocksize <number>\t\tSets the blocksize (default: 512)");
                     println!("  -w, --windowsize <number>\t\tSets the windowsize (default: 1)");
-                    println!(
-                        "  -t, --timeout <seconds>\t\tSets the timeout in seconds (default: 5)"
-                    );
+                    println!("  -t, --timeout <seconds>\t\tSets the timeout in seconds (default: 5)");
                     println!("  -u, --upload\t\t\t\tSets the client to upload mode, Ignores all previous download flags");
                     println!("  -d, --download\t\t\tSet the client to download mode, Invalidates all previous upload flags");
                     println!("  -rd, --receive-directory <DIRECTORY>\tSet the directory to receive files when in Download mode (default: current working directory)");
-                    println!("  --keep-on-error\t\t\t\tPrevent client from deleting files after receiving errors");
+                    println!("  --keep-on-error\t\t\tPrevent client from deleting files after receiving errors");
                     println!("  -h, --help\t\t\t\tPrint help information");
                     process::exit(0);
                 }
@@ -149,6 +154,10 @@ impl ClientConfig {
                 }
             }
         }
+
+                if config.file_path.as_os_str().is_empty() {
+                    return Err("missing filename".into());
+                }
 
         Ok(config)
     }

--- a/src/client_main.rs
+++ b/src/client_main.rs
@@ -9,7 +9,8 @@ fn main() {
 }
 
 fn client<T: Iterator<Item = String>>(args: T) -> Result<(), Box<dyn Error>> {
-    let config = ClientConfig::new(args).unwrap_or_else(|err| {
+    // Parse arguments, skipping first one (exec name)
+    let config = ClientConfig::new(args.skip(1)).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {err}");
         process::exit(1)
     });

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,9 +124,7 @@ impl Config {
                     println!("Usage: tftpd [OPTIONS]\n");
                     println!("Options:");
                     println!("  -i, --ip-address <IP ADDRESS>\t\tSet the ip address of the server (default: 127.0.0.1)");
-                    println!(
-                        "  -p, --port <PORT>\t\t\tSet the listening port of the server (default: 69)"
-                    );
+                    println!("  -p, --port <PORT>\t\t\tSet the listening port of the server (default: 69)");
                     println!("  -d, --directory <DIRECTORY>\t\tSet the serving directory (default: current working directory)");
                     println!("  -rd, --receive-directory <DIRECTORY>\tSet the directory to receive files to (default: the directory setting)");
                     println!("  -sd, --send-directory <DIRECTORY>\tSet the directory to send files from (default: the directory setting)");
@@ -134,7 +132,7 @@ impl Config {
                     println!("  -r, --read-only\t\t\tRefuse all write requests, making the server read-only (default: false)");
                     println!("  --duplicate-packets <NUM>\t\tDuplicate all packets sent from the server (default: 0)");
                     println!("  --overwrite\t\t\t\tOverwrite existing files (default: false)");
-                    println!("  --keep-on-error\t\t\t\tPrevent daemon from deleting files after receiving errors");
+                    println!("  --keep-on-error\t\t\tPrevent daemon from deleting files after receiving errors");
                     println!("  -h, --help\t\t\t\tPrint help information");
                     process::exit(0);
                 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,8 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
 use std::{env, process};
 
+use crate::server::DEFAULT_MAX_RETRIES;
+
 /// Configuration `struct` used for parsing TFTP options from user
 /// input.
 ///
@@ -39,6 +41,8 @@ pub struct Config {
     pub overwrite: bool,
     /// Should clean (delete) files after receiving errors. (default: true)
     pub clean_on_error: bool,
+    /// Max count of retires (default: 6)
+    pub max_retries: usize,
 }
 
 impl Default for Config {
@@ -54,6 +58,7 @@ impl Default for Config {
             duplicate_packets: Default::default(),
             overwrite: Default::default(),
             clean_on_error: true,
+            max_retries: DEFAULT_MAX_RETRIES,
         }
     }
 }
@@ -119,6 +124,13 @@ impl Config {
                 "-r" | "--read-only" => {
                     config.read_only = true;
                 }
+                "-m" | "--maxretries" => {
+                    if let Some(retries_str) = args.next() {
+                        config.max_retries = retries_str.parse::<usize>()?;
+                    } else {
+                        return Err("Missing max retries after flag".into());
+                    }
+                }
                 "-h" | "--help" => {
                     println!("TFTP Server Daemon\n");
                     println!("Usage: tftpd [OPTIONS]\n");
@@ -130,6 +142,7 @@ impl Config {
                     println!("  -sd, --send-directory <DIRECTORY>\tSet the directory to send files from (default: the directory setting)");
                     println!("  -s, --single-port\t\t\tUse a single port for both sending and receiving (default: false)");
                     println!("  -r, --read-only\t\t\tRefuse all write requests, making the server read-only (default: false)");
+                    println!("  -m, --maxretries <cnt>\t\tSets the max retries count (default: 6)");
                     println!("  --duplicate-packets <NUM>\t\tDuplicate all packets sent from the server (default: 0)");
                     println!("  --overwrite\t\t\t\tOverwrite existing files (default: false)");
                     println!("  --keep-on-error\t\t\tPrevent daemon from deleting files after receiving errors");

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -200,6 +200,8 @@ pub enum OptionType {
     TransferSize,
     /// Timeout option type
     Timeout,
+    /// Timeout in ms option type
+    TimeoutMs,
     /// Windowsize option type
     Windowsize,
 }
@@ -211,6 +213,7 @@ impl OptionType {
             OptionType::BlockSize => "blksize",
             OptionType::TransferSize => "tsize",
             OptionType::Timeout => "timeout",
+            OptionType::TimeoutMs => "timeoutms",
             OptionType::Windowsize => "windowsize",
         }
     }
@@ -225,6 +228,7 @@ impl FromStr for OptionType {
             "blksize" => Ok(OptionType::BlockSize),
             "tsize" => Ok(OptionType::TransferSize),
             "timeout" => Ok(OptionType::Timeout),
+            "timeoutms" => Ok(OptionType::TimeoutMs),
             "windowsize" => Ok(OptionType::Windowsize),
             _ => Err("Invalid option type"),
         }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -267,6 +267,8 @@ pub enum ErrorCode {
     FileExists = 6,
     /// No such user error code
     NoSuchUser = 7,
+    /// Refused option error code
+    RefusedOption = 8,
 }
 
 impl ErrorCode {
@@ -281,6 +283,7 @@ impl ErrorCode {
             5 => Ok(ErrorCode::UnknownId),
             6 => Ok(ErrorCode::FileExists),
             7 => Ok(ErrorCode::NoSuchUser),
+            8 => Ok(ErrorCode::RefusedOption),
             _ => Err("Invalid error code"),
         }
     }
@@ -302,6 +305,7 @@ impl fmt::Display for ErrorCode {
             ErrorCode::UnknownId => write!(f, "Unknown ID"),
             ErrorCode::FileExists => write!(f, "File Exists"),
             ErrorCode::NoSuchUser => write!(f, "No Such User"),
+            ErrorCode::RefusedOption => write!(f, "Refused option"),
         }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -342,6 +342,9 @@ fn parse_options(
                 }
                 worker_options.timeout = Duration::from_secs(*value as u64);
             }
+            OptionType::TimeoutMs => {
+                worker_options.timeout = Duration::from_millis(*value as u64);
+            }
             OptionType::Windowsize => {
                 if *value == 0 || *value > u16::MAX as usize {
                     return Err("Invalid windowsize value");
@@ -389,10 +392,12 @@ fn accept_request<T: Socket>(
 
 fn check_file_exists(file: &Path, directory: &PathBuf) -> ErrorCode {
     if !validate_file_path(file, directory) {
+        eprintln!("Cannot access {} in {}", file.display(), directory.display());
         return ErrorCode::AccessViolation;
     }
 
     if !file.exists() {
+        eprintln!("Cannot find {} in {}", file.display(), directory.display());
         return ErrorCode::FileNotFound;
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -242,7 +242,7 @@ impl Server {
                 self.duplicate_packets + 1,
                 self.max_retries,
             );
-            worker.receive()?;
+            worker.receive(worker_options.transfer_size)?;
             Ok(())
         };
 
@@ -291,7 +291,7 @@ impl Server {
 #[derive(Debug, PartialEq)]
 struct WorkerOptions {
     block_size: usize,
-    transfer_size: u64,
+    transfer_size: usize,
     timeout: Duration,
     window_size: u16,
 }
@@ -337,9 +337,9 @@ fn parse_options(
             OptionType::TransferSize => match request_type {
                 RequestType::Read(size) => {
                     *value = size as usize;
-                    worker_options.transfer_size = size;
+                    worker_options.transfer_size = size as usize;
                 }
-                RequestType::Write => worker_options.transfer_size = *value as u64,
+                RequestType::Write => worker_options.transfer_size = *value as usize,
             },
             OptionType::Timeout => {
                 if *value == 0 {

--- a/src/server.rs
+++ b/src/server.rs
@@ -339,7 +339,7 @@ fn parse_options(
                     *value = size as usize;
                     worker_options.transfer_size = size as usize;
                 }
-                RequestType::Write => worker_options.transfer_size = *value as usize,
+                RequestType::Write => worker_options.transfer_size = *value,
             },
             OptionType::Timeout => {
                 if *value == 0 {

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,9 +8,10 @@ use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::sync::mpsc::Sender;
 use std::time::Duration;
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
-const DEFAULT_BLOCK_SIZE: usize = 512;
-const DEFAULT_WINDOW_SIZE: u16 = 1;
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
+pub const DEFAULT_BLOCK_SIZE: usize = 512;
+pub const DEFAULT_WINDOW_SIZE: u16 = 1;
+pub const DEFAULT_MAX_RETRIES: usize = 6;
 
 /// Server `struct` is used for handling incoming TFTP requests.
 ///
@@ -38,6 +39,7 @@ pub struct Server {
     duplicate_packets: u8,
     largest_block_size: usize,
     clients: HashMap<SocketAddr, Sender<Packet>>,
+    max_retries: usize,
 }
 
 impl Server {
@@ -55,6 +57,7 @@ impl Server {
             duplicate_packets: config.duplicate_packets,
             largest_block_size: DEFAULT_BLOCK_SIZE,
             clients: HashMap::new(),
+            max_retries: config.max_retries,
         };
 
         Ok(server)
@@ -166,7 +169,7 @@ impl Server {
                 let mut socket: Box<dyn Socket>;
 
                 if self.single_port {
-                    let single_socket = create_single_socket(&self.socket, to)?;
+                    let single_socket = create_single_socket(&self.socket, to, worker_options.timeout)?;
                     self.clients.insert(*to, single_socket.sender());
                     self.largest_block_size =
                         max(self.largest_block_size, worker_options.block_size);
@@ -193,6 +196,7 @@ impl Server {
                     worker_options.timeout,
                     worker_options.window_size,
                     self.duplicate_packets + 1,
+                    self.max_retries,
                 );
                 worker.send(!options.is_empty())?;
                 Ok(())
@@ -214,7 +218,7 @@ impl Server {
             let mut socket: Box<dyn Socket>;
 
             if self.single_port {
-                let single_socket = create_single_socket(&self.socket, to)?;
+                let single_socket = create_single_socket(&self.socket, to, worker_options.timeout)?;
                 self.clients.insert(*to, single_socket.sender());
                 self.largest_block_size = max(self.largest_block_size, worker_options.block_size);
 
@@ -236,6 +240,7 @@ impl Server {
                 worker_options.timeout,
                 worker_options.window_size,
                 self.duplicate_packets + 1,
+                self.max_retries,
             );
             worker.receive()?;
             Ok(())
@@ -360,8 +365,9 @@ fn parse_options(
 fn create_single_socket(
     socket: &UdpSocket,
     remote: &SocketAddr,
+    timeout: Duration,
 ) -> Result<ServerSocket, Box<dyn Error>> {
-    let socket = ServerSocket::new(socket.try_clone()?, *remote);
+    let socket = ServerSocket::new(socket.try_clone()?, *remote, timeout);
 
     Ok(socket)
 }

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -9,7 +9,6 @@ use std::{
     time::Duration,
 };
 
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(5);
 const MAX_REQUEST_PACKET_SIZE: usize = 512;
 
 /// Socket `trait` is used to allow building custom sockets to be used for
@@ -167,14 +166,14 @@ impl Socket for ServerSocket {
 
 impl ServerSocket {
     /// Creates a new [`ServerSocket`] from a [`UdpSocket`] and a remote [`SocketAddr`].
-    pub fn new(socket: UdpSocket, remote: SocketAddr) -> Self {
+    pub fn new(socket: UdpSocket, remote: SocketAddr, timeout: Duration) -> Self {
         let (sender, receiver) = mpsc::channel();
         Self {
             socket,
             remote,
             sender: Mutex::new(sender),
             receiver: Mutex::new(receiver),
-            timeout: DEFAULT_TIMEOUT,
+            timeout,
         }
     }
 

--- a/src/window.rs
+++ b/src/window.rs
@@ -112,6 +112,11 @@ impl Window {
     pub fn is_full(&self) -> bool {
         self.elements.len() as u16 == self.size
     }
+
+    /// Returns the length of the file
+    pub fn file_len(&self) -> Result<usize, Box<dyn Error>> {
+        Ok(self.file.metadata()?.len() as usize)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
So I separated a bit the different commits in 3 PR.

This first one contains the following changes [afterwards: still quite big... I can split it again if you request it, I would understand]:

- put all the DEFAULT_xxx glob var in one place
- add timeout_req arg (local option): timeout after the 1st packet (RRQ/WRQ), different to the timeout for the following packets, as the delay can be longer 
- add max_retries arg (local option): so it can be set on S and C sides 
- transfer size: checked at the end of the transfer
- factorize upload() and download() functions in client
- accept float for timeout arg, and use non-standard "timeoutms" negociated option in order to retry packets in less than 1s
- client use options negotiated with server instead of those on the command line, as per standard
- cleanup a bit the help message
- better argument parsing: e.g. client must get exactly one filename, use optional '--' if filename starts with '-'
- add error code "refused option" as per standard
- in the send loop, retry count was not working well, this is corrected the the send loop is rewritten anyway in the next PR
- send loop again, cnx reset specific error is printed. We may want to abort retries here as it probably means the remote port is closed, but I am still unsure about that.

And:
- bad change: in check_file_exists(), I added two spurious error messages; this is was a bad idea as it must be done elsewhere, I corrected it in the next PR and I am too lazy to change it now.
