### PR TITLE
feat: add millisecond retry for tftpc

### DIFF
--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -102,7 +102,14 @@ impl ClientConfig {
                 }
                 "-t" | "--timeout" => {
                     if let Some(timeout_str) = args.next() {
-                        config.timeout = Duration::from_secs(timeout_str.parse::<u64>()?);
+                        if timeout_str.contains('.') {
+                            config.timeout = Duration::from_secs_f32(timeout_str.parse::<f32>()?);
+                            if config.timeout < Duration::from_secs_f32(0.001) {
+                                return Err("timeout cannot be shorter than 1 ms".into());
+                            }                           
+                        } else {
+                            config.timeout = Duration::from_secs(timeout_str.parse::<u64>()?);
+                        }
                     } else {
                         return Err("Missing timeout after flag".into());
                     }
@@ -134,13 +141,11 @@ impl ClientConfig {
                     println!("  -p, --port <PORT>\t\t\tPort of the server (default: 69)");
                     println!("  -b, --blocksize <number>\t\tSets the blocksize (default: 512)");
                     println!("  -w, --windowsize <number>\t\tSets the windowsize (default: 1)");
-                    println!(
-                        "  -t, --timeout <seconds>\t\tSets the timeout in seconds (default: 5)"
-                    );
+                    println!("  -t, --timeout <seconds>\t\tSets the timeout in seconds (default: 5)");
                     println!("  -u, --upload\t\t\t\tSets the client to upload mode, Ignores all previous download flags");
                     println!("  -d, --download\t\t\tSet the client to download mode, Invalidates all previous upload flags");
                     println!("  -rd, --receive-directory <DIRECTORY>\tSet the directory to receive files when in Download mode (default: current working directory)");
-                    println!("  --keep-on-error\t\t\t\tPrevent client from deleting files after receiving errors");
+                    println!("  --keep-on-error\t\t\tPrevent client from deleting files after receiving errors");
                     println!("  -h, --help\t\t\t\tPrint help information");
                     process::exit(0);
                 }
@@ -149,6 +154,10 @@ impl ClientConfig {
                 }
             }
         }
+
+                if config.file_path.as_os_str().is_empty() {
+                    return Err("missing filename".into());
+                }
 
         Ok(config)
     }

--- a/src/client_main.rs
+++ b/src/client_main.rs
@@ -9,7 +9,8 @@ fn main() {
 }
 
 fn client<T: Iterator<Item = String>>(args: T) -> Result<(), Box<dyn Error>> {
-    let config = ClientConfig::new(args).unwrap_or_else(|err| {
+    // Parse arguments, skipping first one (exec name)
+    let config = ClientConfig::new(args.skip(1)).unwrap_or_else(|err| {
         eprintln!("Problem parsing arguments: {err}");
         process::exit(1)
     });

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,9 +124,7 @@ impl Config {
                     println!("Usage: tftpd [OPTIONS]\n");
                     println!("Options:");
                     println!("  -i, --ip-address <IP ADDRESS>\t\tSet the ip address of the server (default: 127.0.0.1)");
-                    println!(
-                        "  -p, --port <PORT>\t\t\tSet the listening port of the server (default: 69)"
-                    );
+                    println!("  -p, --port <PORT>\t\t\tSet the listening port of the server (default: 69)");
                     println!("  -d, --directory <DIRECTORY>\t\tSet the serving directory (default: current working directory)");
                     println!("  -rd, --receive-directory <DIRECTORY>\tSet the directory to receive files to (default: the directory setting)");
                     println!("  -sd, --send-directory <DIRECTORY>\tSet the directory to send files from (default: the directory setting)");
@@ -134,7 +132,7 @@ impl Config {
                     println!("  -r, --read-only\t\t\tRefuse all write requests, making the server read-only (default: false)");
                     println!("  --duplicate-packets <NUM>\t\tDuplicate all packets sent from the server (default: 0)");
                     println!("  --overwrite\t\t\t\tOverwrite existing files (default: false)");
-                    println!("  --keep-on-error\t\t\t\tPrevent daemon from deleting files after receiving errors");
+                    println!("  --keep-on-error\t\t\tPrevent daemon from deleting files after receiving errors");
                     println!("  -h, --help\t\t\t\tPrint help information");
                     process::exit(0);
                 }

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -200,6 +200,8 @@ pub enum OptionType {
     TransferSize,
     /// Timeout option type
     Timeout,
+    /// Timeout in ms option type
+    TimeoutMs,
     /// Windowsize option type
     Windowsize,
 }
@@ -211,6 +213,7 @@ impl OptionType {
             OptionType::BlockSize => "blksize",
             OptionType::TransferSize => "tsize",
             OptionType::Timeout => "timeout",
+            OptionType::TimeoutMs => "timeoutms",
             OptionType::Windowsize => "windowsize",
         }
     }
@@ -225,6 +228,7 @@ impl FromStr for OptionType {
             "blksize" => Ok(OptionType::BlockSize),
             "tsize" => Ok(OptionType::TransferSize),
             "timeout" => Ok(OptionType::Timeout),
+            "timeoutms" => Ok(OptionType::TimeoutMs),
             "windowsize" => Ok(OptionType::Windowsize),
             _ => Err("Invalid option type"),
         }


### PR DESCRIPTION
- factorize upload() and download() functions in client
- accept float for timeout arg, and use non-standard "timeoutms" negociated option in order to retry packets in less than 1s
- better argument parsing: client must get exactly one filename from CLI

bad change: in check_file_exists(), I added two spurious error messages... i tries 3 times git rebase but I cannot get github to amend this commit ! This is anyway removed in a next commit.

