### PR TITLE
configure block sequence rollover policy

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,5 @@
 use crate::server::{
+    Rollover,
     DEFAULT_BLOCK_SIZE,
     DEFAULT_WINDOW_SIZE,
     DEFAULT_WINDOW_WAIT,
@@ -39,6 +40,7 @@ pub struct Client {
     receive_directory: PathBuf,
     clean_on_error: bool,
     transfer_size: usize,
+    rollover: Rollover,
 }
 
 /// Enum used to set the client either in Download Mode or Upload Mode
@@ -66,6 +68,7 @@ impl Client {
             receive_directory: config.receive_directory.clone(),
             clean_on_error: config.clean_on_error,
             transfer_size: 0,
+            rollover: config.rollover,
         })
     }
 
@@ -277,6 +280,7 @@ impl Client {
                 self.window_wait,
                 1,
                 self.max_retries,
+                self.rollover,
             )
         } else {
             Worker::new(
@@ -289,6 +293,7 @@ impl Client {
                 self.window_wait,
                 1,
                 self.max_retries,
+                self.rollover,
             )
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,7 @@ pub use packet::OptionType;
 pub use packet::Packet;
 pub use packet::TransferOption;
 pub use server::Server;
+pub use server::Rollover;
 pub use socket::ServerSocket;
 pub use socket::Socket;
 pub use window::Window;


### PR DESCRIPTION
This last patch (for the moment!) adds the --rollover option to configure how each endpoint should manage sequence rollover every ~65535 blocks (big files). 

This rollover problem is not trivial to address because it is not specified in the RFCs ; most tools seem to use 0 but there is an aviation standard which requires 1 for instance.

It can be set on each side, and will not be negotiated. This resource here propose it as a negotiated option: https://www.compuphase.com/tftp.htm (many interesting things about tftp), but I do not think it makes sense.

Argument can be 0, 1, n (no rollover allowed), x (don't care). 

In case of n, transfer will stop with an error if it reaches the rollover.

With x, the sender will use 0, and the receiver will accept 0 or 1... but if the sender use 0 and the packet get lost, and 'tsize' is not use, it will end in file corruption.

The default value is 0.

Of course, all the possible cases have been manually tested (and I plan to add automated tests to exercise this option).

Overall, all the tests should be working, but there is still one warning from clippy complaining about too many arguments for Worker::new(). This will be a bit tricky to address, but I have some ideas we can discuss later.