### PR TITLE
Added debug option to drop packets during transfer and added new tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,10 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Install atftp
+      - name: Install atftp and curl
         run: |
           sudo apt-get update
-          sudo apt-get install atftp
+          sudo apt-get install atftp curl
       - name: Build
         run: cargo build --features client --verbose
       - name: Run tests

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,5 +19,6 @@ name = "tftpd"
 path = "src/main.rs"
 
 [features]
-integration = []
 client = []
+integration = ["debug_drop"]
+debug_drop = []

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -15,6 +15,9 @@ use std::path::{Path, PathBuf};
 use std::process;
 use std::time::Duration;
 
+#[cfg(feature = "debug_drop")]
+use crate::drop::drop_set;
+
 /// Configuration `struct` used for parsing TFTP Client options from user
 /// input.
 ///
@@ -202,6 +205,8 @@ impl ClientConfig {
                 }
                 "-q" | "--quiet" => verbosity -= 1,
                 "-v" | "--verbose" => verbosity += 1,
+                #[cfg(feature = "debug_drop")]
+                "-D" => drop_set(args.next())?,
                 "--" => {
                     while let Some(arg) = args.next() {
                         if !config.file_path.as_os_str().is_empty() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,9 @@ use crate::server::{
     DEFAULT_ROLLOVER};
 use crate::log::*;
 
+#[cfg(feature = "debug_drop")]
+use crate::drop::drop_set;
+
 /// Configuration `struct` used for parsing TFTP options from user
 /// input.
 ///
@@ -195,6 +198,8 @@ impl Config {
                 }
                 "-q" | "--quiet" => verbosity -= 1,
                 "-v" | "--verbose" => verbosity += 1,
+                #[cfg(feature = "debug_drop")]
+                "-D" => drop_set(args.next())?,
                 invalid => return Err(format!("Invalid flag: {invalid}").into()),
             }
         }

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,0 +1,46 @@
+#![cfg(feature = "debug_drop")]
+
+use std::sync::Mutex;
+use std::error::Error;
+//use std::sync::atomic::{AtomicU64, Ordering};
+
+use crate::Packet;
+
+///* The 0 to 4 seq numbers (16b) to discard are stored in a atomic u64 */
+//static TX_DROP: AtomicU64 = AtomicU64::new(0);
+static TX_DROP: Mutex<Vec<i32>> = Mutex::new(Vec::new());
+
+
+pub fn drop_set(opt : Option<String>) -> Result<(), Box<dyn Error>> {
+    if let Some(arg) = opt {
+        let mut tx_drop = TX_DROP.lock().unwrap();
+        for val in arg.split(',') {
+            let val_num = val.parse::<i32>()?;
+            tx_drop.push(val_num);
+        }
+        Ok(())
+    } else {
+        Err("Missing argument".into())
+    }
+}
+
+fn check_seq_num(num: u16) -> bool
+{
+    let mut tx_drop = TX_DROP.lock().unwrap();
+    if !tx_drop.is_empty() {
+        if tx_drop[0] == num as i32 {
+            tx_drop.remove(0);
+             return true;
+        }
+    }
+    false
+}
+
+pub fn drop_check(packet: &Packet) -> bool
+{
+    match packet {
+        Packet::Data{block_num, data: _ } => check_seq_num(*block_num),
+        Packet::Ack(block_num) => check_seq_num(*block_num),
+        _ => false,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,9 @@ mod window;
 mod worker;
 mod log;
 
+#[cfg(feature = "debug_drop")]
+mod drop;
+
 #[cfg(feature = "client")]
 pub use client::Client;
 #[cfg(feature = "client")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -251,6 +251,7 @@ impl Server {
             socket.set_read_timeout(worker_options.timeout)?;
             socket.set_write_timeout(worker_options.timeout)?;
 
+            log_dbg!("Accepted options: {}", OptionFmt(options));
             accept_request(&socket, options, RequestType::Write)?;
 
             let worker = Worker::new(

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@
 use std::fs::{self, create_dir_all, remove_dir_all};
 use std::process::{Child, Command, ExitStatus};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 const SERVER_DIR: &str = "target/integration/server";
 const CLIENT_DIR: &str = "target/integration/client";
@@ -280,7 +280,7 @@ fn test_client_receive_paths() {
     let port = "6982";
     create_dir_all(format!("{SERVER_DIR}/subdir").as_str())
         .expect("error creating server directory");
-    create_file(format!("{SERVER_DIR}/subdir/{filename}").as_str());
+    create_file(format!("{SERVER_DIR}/subdir/{filename}").as_str(), 10*1024*1024);
 
     let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR]);
     thread::sleep(Duration::from_secs(1));
@@ -315,7 +315,7 @@ fn test_client_receive_windows_paths() {
     let port = "6983";
     create_dir_all(format!("{SERVER_DIR}/windir").as_str())
         .expect("error creating server directory");
-    create_file(format!("{SERVER_DIR}/windir/{filename}").as_str());
+    create_file(format!("{SERVER_DIR}/windir/{filename}").as_str(), 10*1024*1024);
 
     let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR]);
     thread::sleep(Duration::from_secs(1));
@@ -344,9 +344,187 @@ fn test_client_receive_windows_paths() {
     assert_eq!(server_content, client_content);
 }
 
+#[test]
+fn test_send_curl() {
+    let filename = "send_curl";
+    let port = "6984";
+    initialize(format!("{SERVER_DIR}/{filename}").as_str());
+
+    // rollover=0, verbosity max, drop 1 data packet at half transfer
+    let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR, "-R", "0", "-v", "-v", "-D", "32768"]);
+    thread::sleep(Duration::from_secs(1));
+    let mut client = CommandRunner::new(
+        "curl",
+        &[
+            "-O", //use remote filename locally
+            "--output-dir", CLIENT_DIR,
+            format!("tftp://127.0.0.1:{port}/{filename}").as_str(),
+            "--tftp-blksize", "150", // blocksize to ensure 1 rollover
+            "--connect-timeout", "3", // timeout = 1s
+        ],
+    );
+
+    let status = client.wait();
+    assert!(status.success());
+}
+
+#[cfg(any())] // disable this test until error code is fixed
+#[test]
+fn test_receive_curl() {
+    let filename = "receive_curl";
+    let port = "6985";
+    initialize(format!("{CLIENT_DIR}/{filename}").as_str());
+
+    // rollover=0, verbosity max, drop 1 data packet at half transfer
+    let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR, "-R", "0", "-v", "-v", "-D", "32768"]);
+    thread::sleep(Duration::from_secs(1));
+    let mut client = CommandRunner::new(
+        "curl",
+        &[
+            "--upload-file",
+            format!("{CLIENT_DIR}/{filename}").as_str(),
+            format!("tftp://127.0.0.1:{port}/").as_str(),
+            "--tftp-blksize", "150", // blocksize to ensure 1 rollover
+            "--connect-timeout", "3", // timeout = 1s
+        ],
+    );
+
+    let status = client.wait();
+    assert!(status.success());
+}
+
+#[test]
+fn test_rollover() {
+    let filename = "rollover";
+    let port = "6986";
+    create_dir_all(format!("{SERVER_DIR}").as_str()).expect("error creating server directory");
+    create_file(format!("{SERVER_DIR}/{filename}").as_str(), 65540);
+
+    let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR, "-R", "0", "-v", "-v", ]);
+    thread::sleep(Duration::from_secs(1));
+
+    let mut client = CommandRunner::new(
+        "target/debug/tftpc",
+        &[
+            filename,
+            "-p", port,
+            "-d",
+            "-rd", CLIENT_DIR,
+            "-R", "0",
+            "-b", "1",
+            "-v", "-v", 
+        ],
+    );
+
+    let status = client.wait();
+    assert!(status.success());
+
+    let server_file = format!("{SERVER_DIR}/{filename}");
+    let client_file = format!("{CLIENT_DIR}/{filename}");
+
+    let server_content = fs::read(server_file).expect("error reading server file");
+    let client_content = fs::read(client_file).expect("error reading client file");
+
+    assert_eq!(server_content, client_content);
+}
+
+#[cfg(any())] // disable this test until error code is fixed
+#[test]
+fn test_rollover_fail() {
+    let filename = "rollover_fail";
+    let port = "6987";
+    create_dir_all(format!("{SERVER_DIR}").as_str()).expect("error creating server directory");
+    create_file(format!("{SERVER_DIR}/{filename}").as_str(), 65540);
+
+    let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR, "-R", "0", "-v", "-v", ]);
+    thread::sleep(Duration::from_secs(1));
+
+    let mut client = CommandRunner::new(
+        "target/debug/tftpc",
+        &[
+            filename,
+            "-p", port,
+            "-d",
+            "-rd", CLIENT_DIR,
+            "-R", "1",
+            "-b", "1",
+        ],
+    );
+
+    let status = client.wait();
+    
+    println!("{status:?}");
+    
+    assert!(!status.success());
+}
+
+#[test]
+fn test_window() {
+    let filename = "window";
+    let port = "6988";
+    initialize(format!("{SERVER_DIR}/{filename}").as_str());
+
+    let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR, "-v", "-v", "-D", "20458", ]);
+    thread::sleep(Duration::from_secs(1));
+
+    let now = Instant::now();
+    let mut client = CommandRunner::new(
+        "target/debug/tftpc",
+        &[
+            "-d", 
+            filename, 
+            "-p", port, 
+            "-rd", CLIENT_DIR,
+            "-w", "8",
+            "-t", "10",
+        ],
+    );
+
+    let status = client.wait();
+    assert!(status.success());
+
+    // Packet drop at window start should not trigger any timeout
+    assert!(now.elapsed() < Duration::from_secs(10));
+     
+    check_files(filename);
+}
+
+
+#[test]
+fn test_window_timeout() {
+    let filename = "window_timeout";
+    let port = "6989";
+    initialize(format!("{SERVER_DIR}/{filename}").as_str());
+
+    let _server = CommandRunner::new("target/debug/tftpd", &["-p", port, "-d", SERVER_DIR, "-v", "-v", "-D", "20464" ]);
+    thread::sleep(Duration::from_secs(1));
+
+    let now = Instant::now();
+    let mut client = CommandRunner::new(
+        "target/debug/tftpc",
+        &[
+            "-d", 
+            filename, 
+            "-p", port, 
+            "-rd", CLIENT_DIR,
+            "-w", "8",
+            "-t", "6",
+        ],
+    );
+
+    let status = client.wait();
+    assert!(status.success());
+
+    // Packet drop at window end should trigger one timeout
+    assert!(now.elapsed() > Duration::from_secs(6));
+
+    check_files(filename);
+}
+
+
 fn initialize(filename: &str) {
     create_folders();
-    create_file(filename);
+    create_file(filename, 10*1024*1024);
 }
 
 fn create_folders() {
@@ -356,13 +534,13 @@ fn create_folders() {
     create_dir_all(CLIENT_DIR).expect("error creating client directory");
 }
 
-fn create_file(filename: &str) {
+fn create_file(filename: &str, size: usize) {
     Command::new("dd")
         .args([
             "if=/dev/urandom",
             format!("of={filename}").as_str(),
-            "bs=1M",
-            "count=10",
+            format!("bs={size}").as_str(),
+            "count=1",
         ])
         .spawn()
         .expect("error creating test file")


### PR DESCRIPTION
I added a new option which allow to discard data or ack packet(s) just before sending them by giving their seq number. 

This is intended to simulate a network failure. It only compiles with the right feature, and it is implemented in a way to avoid meddling with eisiting code.

New tests were added... except that some are failing ! which is a good news, as it allowed to discover some bugs. These tests are disabled until I fix them. So the new bugs are :
- error in received loop in case of timeout
- exit code for client is always success, even after a failure
- "sorcerer apprentice syndrome", not actually detected by the tests but showing up in network capture. This one is described in RFC 1123 and must be implemented in TFTP as per RFC 1350




