### PR TITLE
Corrected exit code and reception loop bugs

### DIFF
--- a/src/client_main.rs
+++ b/src/client_main.rs
@@ -1,14 +1,18 @@
-use std::error::Error;
-use std::{env, net::SocketAddr, process};
+use std::{error::Error, env, net::SocketAddr, process, process::ExitCode};
 use tftpd::{Client, ClientConfig, Mode, log_err, log_info};
 
-fn main() {
-    client(env::args()).unwrap_or_else(|err| {
-        log_err!("{err}");
-    })
+fn main() -> ExitCode{
+    match client(env::args()) {
+        Ok(true) => ExitCode::SUCCESS,
+        Ok(false) => ExitCode::FAILURE,
+        Err(err) => {
+            log_err!("{err}");
+            ExitCode::FAILURE
+        }
+    }
 }
 
-fn client<T: Iterator<Item = String>>(args: T) -> Result<(), Box<dyn Error>> {
+fn client<T: Iterator<Item = String>>(args: T) -> Result<bool, Box<dyn Error>> {
     // Parse arguments, skipping first one (exec name)
     let config = ClientConfig::new(args.skip(1)).unwrap_or_else(|err| {
         log_err!("Problem parsing arguments: {err}");

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -368,7 +368,6 @@ fn test_send_curl() {
     assert!(status.success());
 }
 
-#[cfg(any())] // disable this test until error code is fixed
 #[test]
 fn test_receive_curl() {
     let filename = "receive_curl";
@@ -428,7 +427,6 @@ fn test_rollover() {
     assert_eq!(server_content, client_content);
 }
 
-#[cfg(any())] // disable this test until error code is fixed
 #[test]
 fn test_rollover_fail() {
     let filename = "rollover_fail";


### PR DESCRIPTION
- Client threads now returns boolean so main function can provide an exit code
- Reception loop is now processing timout or errors differently, which allows correct management of lost packets
- Tests checking previous behavior now successful, so re-enabled

Integrations tests run locally on Windows 11 and Ubuntu 22