### PR TITLE
Fix duplicated data packet sending

### DIFF
--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -164,7 +164,7 @@ impl ClientConfig {
                 #[cfg(feature = "debug_drop")]
                 "-D" => drop_set(args.next())?,
                 "--" => {
-                    while let Some(arg) = args.next() {
+                    for arg in args.by_ref() {
                         if !config.file_path.as_os_str().is_empty() {
                             return Err("too many arguments".into());
                         }

--- a/src/drop.rs
+++ b/src/drop.rs
@@ -1,15 +1,9 @@
-#![cfg(feature = "debug_drop")]
-
 use std::sync::Mutex;
 use std::error::Error;
-//use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::Packet;
 
-///* The 0 to 4 seq numbers (16b) to discard are stored in a atomic u64 */
-//static TX_DROP: AtomicU64 = AtomicU64::new(0);
 static TX_DROP: Mutex<Vec<i32>> = Mutex::new(Vec::new());
-
 
 pub fn drop_set(opt : Option<String>) -> Result<(), Box<dyn Error>> {
     if let Some(arg) = opt {
@@ -27,11 +21,9 @@ pub fn drop_set(opt : Option<String>) -> Result<(), Box<dyn Error>> {
 fn check_seq_num(num: u16) -> bool
 {
     let mut tx_drop = TX_DROP.lock().unwrap();
-    if !tx_drop.is_empty() {
-        if tx_drop[0] == num as i32 {
-            tx_drop.remove(0);
-             return true;
-        }
+    if !tx_drop.is_empty() && tx_drop[0] == num as i32 {
+        tx_drop.remove(0);
+         return true;
     }
     false
 }


### PR DESCRIPTION
- Send et receive loops in worker.rs reworked to prevent data packet duplication after a missing packet (problem known as sorcerer's apprentice syndrom: SAS, cf RFC 1123)
- Added related integration test which counts dups in stdout
- corrected style for clippy

Many local tests done on Win11 and Ubuntu, but not as many as I want... I will continue doing more checks