### PR TITLE
IO buffering + remote filename + options processing bug

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -105,6 +105,8 @@ impl Client {
                 socket.connect(from)?;
                 match packet {
                     Packet::Oack(options) => {
+                        // Reset options before applying those from server
+                        self.opt_common = Default::default();
                         self.opt_common.apply(&options)?;
                         log_dbg!("  Accepted options: {}", OptionFmt(&options));
                         let worker = self.configure_worker(socket)?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -87,8 +87,9 @@ impl Client {
                 .file_local
                 .file_name()
                 .ok_or("Invalid filename")?
-                .display()
-                .to_string();
+                .to_str()
+                .ok_or("Filename is not valid UTF-8")?
+                .to_owned();
         }
 
         self.opt_common.transfer_size = Some(fs::metadata(self.file_local.clone())?.len());

--- a/src/client.rs
+++ b/src/client.rs
@@ -173,6 +173,8 @@ impl Client {
                 socket.connect(from)?;
                 match packet {
                     Packet::Oack(options) => {
+                        // Reset options before applying those from server
+                        self.opt_common = Default::default();
                         self.opt_common.apply(&options)?;
                         log_dbg!("  Accepted options: {}", OptionFmt(&options));
                         Socket::send_to(&socket, &Packet::Ack(0), &from)?;

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -167,6 +167,8 @@ impl ClientConfig {
                     println!("  -d, --download\t\t\tselect download mode, ignores previous flags");
                     println!("  -rd, --receive-directory <DIR>\tdirectory to receive files when in Download mode (default: current)");
                     config::print_opt_local_help();
+                    println!("  -v, --verbose\t\t\t\tIncrease log verbosity (can be repeated, e.g. -vv)");
+                    println!("  -q, --quiet\t\t\t\tDecrease log verbosity (can be repeated)");
                     println!("  -h, --help\t\t\t\tprint help information");
                     println!("  -V, --version\t\t\t\tprint version");
                     process::exit(0);

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -41,6 +41,8 @@ pub struct ClientConfig {
     pub receive_directory: PathBuf,
     /// File to Upload or Download.
     pub file_path: PathBuf,
+    /// Optional file path to send to server.
+    pub file_remote: String,
     /// Local options for client
     pub opt_local: OptionsPrivate,
     /// Common options for client
@@ -56,6 +58,7 @@ impl Default for ClientConfig {
             mode: Mode::Download,
             receive_directory: Default::default(),
             file_path: Default::default(),
+            file_remote: Default::default(),
             opt_local: Default::default(),
             opt_common: Default::default(),
         }
@@ -151,7 +154,7 @@ impl ClientConfig {
                 }
                 "-h" | "--help" => {
                     println!("TFTP Client\n");
-                    println!("Usage: tftpd client <File> [OPTIONS]\n");
+                    println!("Usage: tftpd client [options] <file> [remote file] \n");
                     println!("Options:");
                     println!("  -i, --ip-address <IP ADDRESS>\t\tIP address of the server (default: 127.0.0.1)");
                     println!("  -p, --port <PORT>\t\t\tUDP port of the server (default: 69)");
@@ -175,25 +178,18 @@ impl ClientConfig {
                 "-D" => drop_set(args.next())?,
                 "--" => {
                     for arg in args.by_ref() {
-                        if !config.file_path.as_os_str().is_empty() {
-                            return Err("too many arguments".into());
-                        }
-                        config.file_path = convert_file_path_abs(arg.as_str());
+                        config.set_paths(&arg)?;
                     }
                 }
                 arg => {
                     if !config::parse_local_args(arg, &mut args, &mut config.opt_local)? {
-                        if !config.file_path.as_os_str().is_empty() {
-                            return Err("too many arguments".into());
-                        }
-
                         if arg.starts_with('-') {
                             return Err(format!(
                                 "unkwon flag {arg} (or use '--' to force into filename)"
                             )
                             .into());
                         }
-                        config.file_path = convert_file_path_abs(arg);
+                        config.set_paths(arg)?;
                     }
                 }
             }
@@ -207,7 +203,19 @@ impl ClientConfig {
 
         Ok(config)
     }
+
+    fn set_paths(&mut self, arg: &str) -> Result<(), Box<dyn Error>> {
+        if self.file_path.as_os_str().is_empty() {
+            self.file_path = convert_file_path_abs(arg);
+        } else if self.file_remote.is_empty() {
+            self.file_remote = arg.to_string();
+        } else {
+            return Err("too many arguments".into());
+        }
+        Ok(())
+    }
 }
+
 
 pub fn convert_file_path_abs(filename: &str) -> PathBuf {
     let normalized_filename = if MAIN_SEPARATOR == '\\' {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,5 +50,6 @@ pub use packet::Packet;
 pub use server::Server;
 pub use socket::ServerSocket;
 pub use socket::Socket;
-pub use window::Window;
+pub use window::WindowRead;
+pub use window::WindowWrite;
 pub use worker::Worker;


### PR DESCRIPTION
Hello Altuğ,

Here are a few changes for TFTP:

- Added IO buffering: Window class is forked into a reader and a writer to allow filling the read buffer (sender side) in advance while waiting for the ack. On a PC the total transfert time gain is very small, but on our embedded system, we gain around 25%. On the receiver side, the gain is very small.

- Added an argument to specify the remote path sent to the server. Currently, the provided path is processed this way:
    -  if the client is uploading, full path is used locally and extracted filename is used remotely
    -  if downloading, rx dir + filename is used locally and full path is used remotely

   The change will keep this behavior with one path, and with two paths, 1st is the local and 2nd is the remote
So the CLI will be `tftpc [xxx] path [remote_path]`.
Also, this features allow interoperability with HPA TFTPD which request the folder name to be provided.

- small bug corrected: if the client tries to negotiate an option and the server ignores it, client choice is kept. Actually it should fall back to default.

I am of course open to discuss any of these changes.

I was BTW thinking of renaming non standard protocol option "timeoutms" to "utimeout" to align it with HPA TFTP. It would  break compatibility with previous version, but as it was introduced recently and is probably not much used I guess this would be a small problem.

Regards,
Antoine