### PR TITLE
Added abort flag + small fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,7 @@ path = "src/main.rs"
 client = []
 integration = ["debug_drop", "client"]
 debug_drop = []
-sigint = [ "dep:signal-hook" ]
 
 [dependencies]
-signal-hook = { version = ">=0.3.0", optional = true }
+signal-hook = { version = ">=0.3.0" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,8 @@ path = "src/main.rs"
 client = []
 integration = ["debug_drop", "client"]
 debug_drop = []
+sigint = [ "dep:signal-hook" ]
+
+[dependencies]
+signal-hook = { version = ">=0.3.0", optional = true }
+

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,8 +3,8 @@ use std::error::Error;
 use std::fs;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::path::PathBuf;
+use std::sync::{atomic::AtomicBool, Arc};
 use std::time::Duration;
-use std::sync::{ atomic::AtomicBool, Arc };
 
 #[cfg(debug_assertions)]
 use crate::options::OptionFmt;
@@ -101,7 +101,7 @@ impl Client {
         Socket::send_to(
             &socket,
             &Packet::Wrq {
-                filename : self.file_remote.clone(),
+                filename: self.file_remote.clone(),
                 mode: "octet".into(),
                 options: self.opt_common.prepare(),
             },
@@ -124,13 +124,17 @@ impl Client {
                         log_dbg!("  Options not accepted, using default");
                     }
 
-                    Packet::Error { code, msg } => return Err(Box::from(format!(
-                        "Client received error from server: {code}: {msg}"
-                    ))),
+                    Packet::Error { code, msg } => {
+                        return Err(Box::from(format!(
+                            "Client received error from server: {code}: {msg}"
+                        )))
+                    }
 
-                    _ => return Err(Box::from(format!(
-                        "Client received unexpected packet from server: {packet:#?}"
-                    ))),
+                    _ => {
+                        return Err(Box::from(format!(
+                            "Client received unexpected packet from server: {packet:#?}"
+                        )))
+                    }
                 }
 
                 let worker = self.configure_worker(socket)?;
@@ -148,14 +152,10 @@ impl Client {
 
         if self.file_remote.is_empty() {
             // 1 path provided: use it as remote and use rxdir + filename as local
-            self.file_remote = self
-                .file_local
-                .display()
-                .to_string();
-            self.file_local = self.receive_directory.join(self
-                .file_local
-                .file_name()
-                .ok_or("Invalid filename")?)
+            self.file_remote = self.file_local.display().to_string();
+            self.file_local = self
+                .receive_directory
+                .join(self.file_local.file_name().ok_or("Invalid filename")?)
         } else {
             // 2 paths provided: prefix the local one with rxdir and use remote as is
             self.file_local = self.receive_directory.join(self.file_local.clone());
@@ -165,7 +165,7 @@ impl Client {
         Socket::send_to(
             &socket,
             &Packet::Rrq {
-                filename : self.file_remote.clone(),
+                filename: self.file_remote.clone(),
                 mode: "octet".into(),
                 options: self.opt_common.prepare(),
             },
@@ -222,8 +222,8 @@ impl Client {
         ))
     }
 
-    /// Retrieve a ref to the abort flag 
+    /// Retrieve a ref to the abort flag
     pub fn get_abort_flag(&self) -> Arc<AtomicBool> {
-            self.abort.clone()
+        self.abort.clone()
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,6 +4,7 @@ use std::fs;
 use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr, UdpSocket};
 use std::path::PathBuf;
 use std::time::Duration;
+use std::sync::{ atomic::AtomicBool, Arc };
 
 #[cfg(debug_assertions)]
 use crate::options::OptionFmt;
@@ -34,6 +35,7 @@ pub struct Client {
     receive_directory: PathBuf,
     opt_local: OptionsPrivate,
     opt_common: OptionsProtocol,
+    abort: Arc<AtomicBool>,
 }
 
 /// Enum used to set the client either in Download Mode or Upload Mode
@@ -57,6 +59,7 @@ impl Client {
             receive_directory: config.receive_directory.clone(),
             opt_local: config.opt_local.clone(),
             opt_common: config.opt_common.clone(),
+            abort: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -215,6 +218,12 @@ impl Client {
             self.file_local.clone(),
             self.opt_local.clone(),
             self.opt_common.clone(),
+            self.abort.clone(),
         ))
+    }
+
+    /// Retrieve a ref to the abort flag 
+    pub fn get_abort_flag(&self) -> Arc<AtomicBool> {
+            self.abort.clone()
     }
 }

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -68,8 +68,8 @@ impl Default for ClientConfig {
 fn parse_duration<T: Iterator<Item = String>>(args: &mut T) -> Result<Duration, Box<dyn Error>> {
     if let Some(dur_str) = args.next() {
         let dur = Duration::from_secs_f32(dur_str.parse::<f32>()?);
-        if dur < Duration::from_secs_f32(0.001) {
-            Err("duration cannot be shorter than 1 ms".into())
+        if dur < Duration::from_secs_f32(0.000001) {
+            Err("duration cannot be shorter than 1 us".into())
         } else if dur > Duration::from_secs(255) {
             Err("duration cannot be greater than 255 s".into())
         } else {

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -160,7 +160,7 @@ impl ClientConfig {
                     println!("  -p, --port <PORT>\t\t\tUDP port of the server (default: 69)");
                     println!("  -b, --blocksize <number>\t\tset the blocksize (default: 512)");
                     println!("  -w, --windowsize <number>\t\tset the windowsize (default: 1)");
-                    println!("  -W, --windowwait <seconds>\t\t inter-packet wait time in seconds for windows (default: 0.01)");
+                    println!("  -W, --windowwait <seconds>\t\t inter-packet wait time in seconds for windows (default: 0)");
                     println!("  -t, --timeout <seconds>\t\tset the timeout for data in seconds (default: 5, can be float)");
                     println!("  -T, --timeout-req <seconds>\t\tset the timeout after request in seconds (default: 5, can be float)");
                     println!("  -u, --upload\t\t\t\tselect upload mode, ignores previous flags");
@@ -199,6 +199,14 @@ impl ClientConfig {
 
         if config.file_path.as_os_str().is_empty() {
             return Err("missing filename".into());
+        }
+
+        if config.opt_common.timeout <= config.opt_common.window_wait {
+            return Err("Inter-packet wait time cannot be exceed timeout".into());
+        }
+
+        if !config.opt_common.window_wait.is_zero() && config.opt_common.window_size == 1 {
+            return Err("Inter-packet wait time needs window size > 1".into());
         }
 
         verbosity_set(verbosity);

--- a/src/client_config.rs
+++ b/src/client_config.rs
@@ -167,7 +167,9 @@ impl ClientConfig {
                     println!("  -d, --download\t\t\tselect download mode, ignores previous flags");
                     println!("  -rd, --receive-directory <DIR>\tdirectory to receive files when in Download mode (default: current)");
                     config::print_opt_local_help();
-                    println!("  -v, --verbose\t\t\t\tIncrease log verbosity (can be repeated, e.g. -vv)");
+                    println!(
+                        "  -v, --verbose\t\t\t\tIncrease log verbosity (can be repeated, e.g. -vv)"
+                    );
                     println!("  -q, --quiet\t\t\t\tDecrease log verbosity (can be repeated)");
                     println!("  -h, --help\t\t\t\tprint help information");
                     println!("  -V, --version\t\t\t\tprint version");
@@ -225,7 +227,6 @@ impl ClientConfig {
         Ok(())
     }
 }
-
 
 pub fn convert_file_path_abs(filename: &str) -> PathBuf {
     let normalized_filename = if MAIN_SEPARATOR == '\\' {

--- a/src/client_main.rs
+++ b/src/client_main.rs
@@ -38,7 +38,7 @@ fn client<T: Iterator<Item = String>>(args: T) -> Result<bool, Box<dyn Error>> {
         );
     }
 
-    #[cfg(feature = "sigint")]
+    // Catch Ctrl-C to exit cleanly by sending error msg
     signal_hook::flag::register(signal_hook::consts::SIGINT, client.get_abort_flag()).unwrap();
 
     client.run()

--- a/src/client_main.rs
+++ b/src/client_main.rs
@@ -38,5 +38,8 @@ fn client<T: Iterator<Item = String>>(args: T) -> Result<bool, Box<dyn Error>> {
         );
     }
 
+    #[cfg(feature = "sigint")]
+    signal_hook::flag::register(signal_hook::consts::SIGINT, client.get_abort_flag()).unwrap();
+
     client.run()
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -200,7 +200,9 @@ impl Config {
                     println!("  -r, --read-only\t\t\tRefuse all write requests, making the server read-only (default: false)");
                     println!("  --overwrite\t\t\t\tOverwrite existing files (default: false)");
                     print_opt_local_help();
-                    println!("  -v, --verbose\t\t\t\tIncrease log verbosity (can be repeated, e.g. -vv)");
+                    println!(
+                        "  -v, --verbose\t\t\t\tIncrease log verbosity (can be repeated, e.g. -vv)"
+                    );
                     println!("  -q, --quiet\t\t\t\tDecrease log verbosity (can be repeated)");
                     println!("  -h, --help\t\t\t\tPrint help information");
                     println!("  -V, --version\t\t\t\tprint version");

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,5 +35,8 @@ fn server<T: Iterator<Item = String>>(args: T) {
         );
     }
 
+    #[cfg(feature = "sigint")]
+    signal_hook::flag::register(signal_hook::consts::SIGINT, server.get_abort_flag()).unwrap();
+
     server.listen();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ fn server<T: Iterator<Item = String>>(args: T) {
         );
     }
 
-    #[cfg(feature = "sigint")]
+    // Catch Ctrl-C to exit cleanly by sending error msg to active cnx
     signal_hook::flag::register(signal_hook::consts::SIGINT, server.get_abort_flag()).unwrap();
 
     server.listen();

--- a/src/options.rs
+++ b/src/options.rs
@@ -94,15 +94,15 @@ impl OptionsProtocol {
             });
         }
 
-        options.push(if self.timeout.subsec_millis() == 0 {
+        options.push(if self.timeout.subsec_micros() == 0 {
             TransferOption {
                 option: OptionType::Timeout,
                 value: self.timeout.as_secs(),
             }
         } else {
             TransferOption {
-                option: OptionType::TimeoutMs,
-                value: self.timeout.as_millis() as u64,
+                option: OptionType::UTimeout,
+                value: self.timeout.as_micros() as u64,
             }
         });
 
@@ -152,12 +152,12 @@ impl OptionsProtocol {
                     }
                     opt_common.timeout = Duration::from_secs(*value);
                 }
-                OptionType::TimeoutMs => {
+                OptionType::UTimeout => {
                     if *value == 0 {
-                        log_warn!("  Invalid timeoutms value 0. Changed to 1.");
+                        log_warn!("  Invalid utimeout value 0. Changed to 1.");
                         *value = 1;
                     }
-                    opt_common.timeout = Duration::from_millis(*value);
+                    opt_common.timeout = Duration::from_micros(*value);
                 }
                 OptionType::WindowSize => {
                     if *value == 0 {
@@ -186,7 +186,7 @@ impl OptionsProtocol {
                 OptionType::WindowSize => self.window_size = option.value as u16,
                 OptionType::WindowWait => self.window_wait = Duration::from_millis(option.value),
                 OptionType::Timeout => self.timeout = Duration::from_secs(option.value),
-                OptionType::TimeoutMs => self.timeout = Duration::from_millis(option.value),
+                OptionType::UTimeout => self.timeout = Duration::from_micros(option.value),
                 OptionType::TransferSize => self.transfer_size = Some(option.value),
             }
         }
@@ -279,8 +279,8 @@ pub enum OptionType {
     TransferSize,
     /// Timeout option type
     Timeout,
-    /// Timeout in ms option type
-    TimeoutMs,
+    /// Timeout in us (micro-s) option type
+    UTimeout,
     /// Windowsize option type
     WindowSize,
     /// Windowwait option type
@@ -294,7 +294,7 @@ impl OptionType {
             OptionType::BlockSize => "blksize",
             OptionType::TransferSize => "tsize",
             OptionType::Timeout => "timeout",
-            OptionType::TimeoutMs => "timeoutms",
+            OptionType::UTimeout => "utimeout",
             OptionType::WindowSize => "windowsize",
             OptionType::WindowWait => "windowwait",
         }
@@ -310,7 +310,7 @@ impl FromStr for OptionType {
             "blksize" => Ok(OptionType::BlockSize),
             "tsize" => Ok(OptionType::TransferSize),
             "timeout" => Ok(OptionType::Timeout),
-            "timeoutms" => Ok(OptionType::TimeoutMs),
+            "utimeout" => Ok(OptionType::UTimeout),
             "windowsize" => Ok(OptionType::WindowSize),
             "windowwait" => Ok(OptionType::WindowWait),
             _ => Err("Invalid option type"),

--- a/src/options.rs
+++ b/src/options.rs
@@ -62,7 +62,7 @@ pub struct OptionsProtocol {
     pub block_size: u16,
     /// Windowsize to use during transfer. (default: 1)
     pub window_size: u16,
-    /// Inter packets wait delay in windows (default: 10ms)
+    /// Inter packets wait delay in windows (default: 0)
     pub window_wait: Duration,
     /// Timeout to use during transfer. (default: 5s)
     pub timeout: Duration,

--- a/src/server.rs
+++ b/src/server.rs
@@ -5,6 +5,8 @@ use std::net::{SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::sync::mpsc::Sender;
 use std::time::Duration;
+use std::sync::{atomic::AtomicBool, Arc};
+
 
 #[cfg(debug_assertions)]
 use crate::options::OptionFmt;
@@ -40,6 +42,7 @@ pub struct Server {
     largest_block_size: u16,
     clients: HashMap<SocketAddr, Sender<Packet>>,
     opt_local: OptionsPrivate,
+    abort: Arc<AtomicBool>,
 }
 
 impl Server {
@@ -56,6 +59,7 @@ impl Server {
             largest_block_size: DEFAULT_BLOCK_SIZE,
             clients: HashMap::new(),
             opt_local: config.opt_local.clone(),
+            abort: Arc::new(AtomicBool::new(false)),
         };
 
         Ok(server)
@@ -63,6 +67,9 @@ impl Server {
 
     /// Starts listening for connections. Note that this function does not finish running until termination.
     pub fn listen(&mut self) {
+        // To check abort flag every seconds
+        self.socket.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+
         loop {
             let received = if self.single_port {
                 self.socket
@@ -127,6 +134,11 @@ impl Server {
                         }
                     }
                 };
+            }
+
+            if self.abort.load(std::sync::atomic::Ordering::Relaxed) {
+                log_err!("TFTP service aborted by user");
+                break;
             }
         }
     }
@@ -197,6 +209,7 @@ impl Server {
                     file_path.clone(),
                     self.opt_local.clone(),
                     worker_options.clone(),
+                    self.abort.clone(),
                 );
                 worker.send(!options.is_empty())?;
                 Ok(())
@@ -238,6 +251,7 @@ impl Server {
                 file_path.clone(),
                 self.opt_local.clone(),
                 worker_options.clone(),
+                self.abort.clone(),
             );
             worker.receive()?;
             Ok(())
@@ -282,6 +296,11 @@ impl Server {
         } else {
             Err("No client found for packet".into())
         }
+    }
+
+    /// Retrieve a ref to the abort flag
+    pub fn get_abort_flag(&self) -> Arc<AtomicBool> {
+        self.abort.clone()
     }
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,9 +4,8 @@ use std::error::Error;
 use std::net::{SocketAddr, UdpSocket};
 use std::path::{Path, PathBuf, MAIN_SEPARATOR};
 use std::sync::mpsc::Sender;
-use std::time::Duration;
 use std::sync::{atomic::AtomicBool, Arc};
-
+use std::time::Duration;
 
 #[cfg(debug_assertions)]
 use crate::options::OptionFmt;
@@ -68,7 +67,9 @@ impl Server {
     /// Starts listening for connections. Note that this function does not finish running until termination.
     pub fn listen(&mut self) {
         // To check abort flag every seconds
-        self.socket.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
+        self.socket
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .unwrap();
 
         loop {
             let received = if self.single_port {

--- a/src/window.rs
+++ b/src/window.rs
@@ -37,10 +37,7 @@ impl WindowRead {
             elements: VecDeque::new(),
             size,
             chunk_size,
-            bufreader: BufReader::with_capacity(
-                2 * size as usize*chunk_size as usize,
-                file,
-            ),
+            bufreader: BufReader::with_capacity(2 * size as usize * chunk_size as usize, file),
         }
     }
 
@@ -95,8 +92,7 @@ impl WindowRead {
     }
 }
 
-
-/// WindowWrite `struct` is used to store data and write them in a file. 
+/// WindowWrite `struct` is used to store data and write them in a file.
 /// It is used to help store the data that is being received for the
 /// [RFC 7440](https://www.rfc-editor.org/rfc/rfc7440) Windowsize option.
 ///

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -15,6 +15,7 @@ use crate::{ErrorCode, Packet, Socket, WindowRead, WindowWrite};
 use crate::drop::drop_check;
 
 const DEFAULT_DUPLICATE_DELAY: Duration = Duration::from_millis(1);
+const MAX_ERROR_PACKET_SIZE: usize = 128;
 
 /// Worker `struct` is used for multithreaded file sending and receiving.
 /// It creates a new socket using the Server's IP and a random port
@@ -196,8 +197,9 @@ impl<T: Socket + ?Sized> Worker<T> {
                 } else {
                     window.prefill()?;
                     self.socket.set_nonblocking(false)?;
-                    timeout_end = Instant::now() + self.opt_common.timeout;
                 }
+
+                timeout_end = Instant::now() + self.opt_common.timeout;
             }
 
             let mut last_ack: Option<u16> = None;
@@ -291,6 +293,7 @@ impl<T: Socket + ?Sized> Worker<T> {
     }
 
     fn receive_file(mut self, file: File) -> Result<u64, Box<dyn Error>> {
+        let max_pkt_size : usize = std::cmp::max(MAX_ERROR_PACKET_SIZE, self.opt_common.block_size as usize);
         let mut block_number: u16 = 0;
         let mut window = WindowWrite::new(
             self.opt_common.window_size,
@@ -306,7 +309,7 @@ impl<T: Socket + ?Sized> Worker<T> {
             while !send_ack {
                 match self
                     .socket
-                    .recv_with_size(self.opt_common.block_size as usize)
+                    .recv_with_size(max_pkt_size)
                 {
                     Ok(Packet::Data {
                         block_num: received_block_number,

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -5,6 +5,7 @@ use std::{
     path::PathBuf,
     thread,
     time::{Duration, Instant},
+    sync::{atomic::AtomicBool, Arc},
 };
 
 use crate::log::*;
@@ -39,6 +40,7 @@ const MAX_ERROR_PACKET_SIZE: usize = 128;
 ///     PathBuf::from_str("Cargo.toml").unwrap(),
 ///     Default::default(),
 ///     Default::default(),
+///     Default::default(),
 /// );
 ///
 /// worker.send(has_options).unwrap();
@@ -48,6 +50,7 @@ pub struct Worker<T: Socket + ?Sized> {
     file_path: PathBuf,
     opt_local: OptionsPrivate,
     opt_common: OptionsProtocol,
+    abort: Arc<AtomicBool>,
 }
 
 impl<T: Socket + ?Sized> Worker<T> {
@@ -57,12 +60,14 @@ impl<T: Socket + ?Sized> Worker<T> {
         file_path: PathBuf,
         opt_local: OptionsPrivate,
         opt_common: OptionsProtocol,
+        abort: Arc<AtomicBool>,
     ) -> Worker<T> {
         Worker {
             socket,
             file_path,
             opt_local,
             opt_common,
+            abort,
         }
     }
 
@@ -204,6 +209,8 @@ impl<T: Socket + ?Sized> Worker<T> {
 
             let mut last_ack: Option<u16> = None;
             loop {
+                self.check_abort()?;
+
                 match self.socket.recv() {
                     Ok(Packet::Ack(block_seq_rx)) => {
                         if last_ack.is_none() {
@@ -393,6 +400,8 @@ impl<T: Socket + ?Sized> Worker<T> {
                         }
                     }
                 }
+
+                self.check_abort()?;
             }
 
             self.send_packet(&Packet::Ack(block_number))?;
@@ -449,5 +458,18 @@ impl<T: Socket + ?Sized> Worker<T> {
         })?;
 
         Err(format!("Unexpected packet received instead of Ack(0): {pkt:#?}").into())
+    }
+
+    fn check_abort(&self) -> Result<(), Box<dyn Error>> {
+        if self.abort.load(std::sync::atomic::Ordering::Relaxed) {
+            self.socket.send(&Packet::Error {
+                code: ErrorCode::NotDefined,
+                msg: "Transfert aborted by user".to_string(),
+            })?;
+
+            Err("Transfert aborted by user".into())
+        } else {
+            Ok(())
+        }
     }
 }

--- a/src/worker.rs
+++ b/src/worker.rs
@@ -3,9 +3,9 @@ use std::{
     fs::{self, File},
     io::ErrorKind,
     path::PathBuf,
+    sync::{atomic::AtomicBool, Arc},
     thread,
     time::{Duration, Instant},
-    sync::{atomic::AtomicBool, Arc},
 };
 
 use crate::log::*;
@@ -16,6 +16,7 @@ use crate::{ErrorCode, Packet, Socket, WindowRead, WindowWrite};
 use crate::drop::drop_check;
 
 const DEFAULT_DUPLICATE_DELAY: Duration = Duration::from_millis(1);
+// Chosen arbitrarily because not specified in RFC
 const MAX_ERROR_PACKET_SIZE: usize = 128;
 
 /// Worker `struct` is used for multithreaded file sending and receiving.
@@ -300,12 +301,11 @@ impl<T: Socket + ?Sized> Worker<T> {
     }
 
     fn receive_file(mut self, file: File) -> Result<u64, Box<dyn Error>> {
-        let max_pkt_size : usize = std::cmp::max(MAX_ERROR_PACKET_SIZE, self.opt_common.block_size as usize);
+        // rx socket size for data and error packets
+        let max_pkt_size: usize =
+            std::cmp::max(MAX_ERROR_PACKET_SIZE, self.opt_common.block_size as usize);
         let mut block_number: u16 = 0;
-        let mut window = WindowWrite::new(
-            self.opt_common.window_size,
-            file,
-        );
+        let mut window = WindowWrite::new(self.opt_common.window_size, file);
         let mut retry_cnt = 0;
 
         let mut last = false;
@@ -314,10 +314,7 @@ impl<T: Socket + ?Sized> Worker<T> {
 
         while !last {
             while !send_ack {
-                match self
-                    .socket
-                    .recv_with_size(max_pkt_size)
-                {
+                match self.socket.recv_with_size(max_pkt_size) {
                     Ok(Packet::Data {
                         block_num: received_block_number,
                         data,


### PR DESCRIPTION
Hello Altug,

This patch contains:
 - small fix: use a min buffer size for rx: if blksize is very small, the socket cannot receive error packets with msg
 - small fix: starting counting for timeout after last pkt, and not window start, in the case a big inter packet delay is used
 - small change: timeoutms option changed to utimeout to work with hpa-tftp (note: it will break compatibility with previous versions but I guess that is not a big issue)
 - big change: added a flag to abort ongoing operations. More details:

We are using the client as a lib and we need to interrupt in a clean way the transfer. When we just drop the client invocation, the thread will continue on its own, and if a new transfer is restarted later, the downloaded file will be corrupted by the two threads writing to it.

So we need to interrupt the worker thread from elsewhere, and the best way is to add an arc+atomic+bool to notify the thread.

On the client, this means sending an error pkt code 0 + msg "xfer canceld by user"  then stopping the thread and exiting.
On the server, same thing for all ongoing cnx, and stopping to listen and exiting.

Also, I used the Unix signal SIGINT to set the flag when compiled as an exec. This add a dependency (signal-hook) and I know you will not like this, so I added the feature "sigint" which will pull this dep only if specified.

Is it ok for you?

Best regards,
Antoine